### PR TITLE
Read transducer input from generic InputStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 .idea
+*.iml
 .settings
 .project
 .classpath

--- a/pom.xml
+++ b/pom.xml
@@ -1,28 +1,33 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<version>1.0.0</version>
+	<version>1.1-SNAPSHOT</version>
 	<groupId>fi.seco</groupId>
 	<artifactId>hfst</artifactId>
 	<name>Thread safe version of Helsinki Finite State Transducers</name>
-<build>
-   <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <!-- or whatever version you use -->
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-    </plugins>
-</build>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<!-- or whatever version you use -->
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<dependencies>
 		<dependency>
 			<groupId>com.carrotsearch</groupId>
 			<artifactId>hppc</artifactId>
-			<version>0.5.2</version>
+			<version>0.6.1</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/fi/seco/hfst/TransducerHeader.java
+++ b/src/main/java/fi/seco/hfst/TransducerHeader.java
@@ -1,8 +1,6 @@
 package fi.seco.hfst;
 
-import java.io.DataInputStream;
-
-// import java.io.DataInputStream;
+import java.io.InputStream;
 
 /**
  * On instantiation reads the transducer's header and provides an interface to
@@ -33,18 +31,18 @@ public class TransducerHeader {
 	 * Read in the (56 bytes of) header information, which unfortunately is
 	 * mostly in little-endian unsigned form.
 	 */
-	public TransducerHeader(DataInputStream file) throws java.io.IOException {
+	public TransducerHeader(InputStream input) throws java.io.IOException {
 		hfst3 = false;
 		intact = true; // could add some checks to toggle this and check outside
 		ByteArray head = new ByteArray(5);
-		file.readFully(head.getBytes());
+		input.read(head.getBytes());
 		if (begins_hfst3_header(head)) {
-			skip_hfst3_header(file);
-			file.readFully(head.getBytes());
+			skip_hfst3_header(input);
+			input.read(head.getBytes());
 			hfst3 = true;
 		}
 		ByteArray b = new ByteArray(head, 56);
-		file.readFully(b.getBytes(), 5, 51);
+		input.read(b.getBytes(), 5, 51);
 
 		number_of_input_symbols = b.getUShort();
 		number_of_symbols = b.getUShort();
@@ -70,13 +68,10 @@ public class TransducerHeader {
 		return (bytes.getUByte() == 72 && bytes.getUByte() == 70 && bytes.getUByte() == 83 && bytes.getUByte() == 84 && bytes.getUByte() == 0);
 	}
 
-	public void skip_hfst3_header(DataInputStream file) throws java.io.IOException {
+	public void skip_hfst3_header(InputStream file) throws java.io.IOException {
 		ByteArray len = new ByteArray(2);
-		file.readFully(len.getBytes());
-		int skip = len.getUShort() + 1;
-		for (int i = 0; i < skip; i++)
-			file.read();
-		//file.skip(len.getUShort() + 1);
+		file.read(len.getBytes());
+		file.skip(len.getUShort() + 1);
 	}
 
 	public int getInputSymbolCount() {

--- a/src/main/java/fi/seco/hfst/UnweightedTransducer.java
+++ b/src/main/java/fi/seco/hfst/UnweightedTransducer.java
@@ -1,6 +1,6 @@
 package fi.seco.hfst;
 
-import java.io.DataInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
@@ -34,9 +34,9 @@ public class UnweightedTransducer implements Transducer {
 			return (ti_inputSymbols[i] == HfstOptimizedLookup.NO_SYMBOL_NUMBER && ti_targets[i] != HfstOptimizedLookup.NO_TABLE_INDEX);
 		}
 
-		public IndexTable(DataInputStream filestream, int indicesCount) throws java.io.IOException {
+		public IndexTable(InputStream input, int indicesCount) throws java.io.IOException {
 			ByteArray b = new ByteArray(indicesCount * 6);
-			filestream.readFully(b.getBytes());
+			input.read(b.getBytes());
 			// each index entry is a unsigned short followed by an unsigned int
 			ti_inputSymbols = new int[indicesCount];
 			ti_targets = new long[indicesCount];
@@ -60,10 +60,10 @@ public class UnweightedTransducer implements Transducer {
 		private final int[] ti_outputSymbols;
 		private final long[] ti_targets;
 
-		public TransitionTable(DataInputStream filestream, int transitionCount) throws java.io.IOException {
+		public TransitionTable(InputStream input, int transitionCount) throws java.io.IOException {
 			ByteArray b = new ByteArray(transitionCount * 8);
 			// each transition entry is two unsigned shorts and an unsigned int
-			filestream.readFully(b.getBytes());
+			input.read(b.getBytes());
 			ti_inputSymbols = new int[transitionCount];
 			ti_outputSymbols = new int[transitionCount];
 			ti_targets = new long[transitionCount];
@@ -143,7 +143,7 @@ public class UnweightedTransducer implements Transducer {
 		}
 	}
 
-	public UnweightedTransducer(DataInputStream file, TransducerHeader h, TransducerAlphabet a) throws java.io.IOException {
+	public UnweightedTransducer(InputStream input, TransducerHeader h, TransducerAlphabet a) throws java.io.IOException {
 		header = h;
 		alphabet = a;
 		operations = alphabet.operations;
@@ -153,8 +153,8 @@ public class UnweightedTransducer implements Transducer {
 			letterTrie.addString(alphabet.keyTable.get(i), i);
 			i++;
 		}
-		indexTable = new IndexTable(file, header.getIndexTableSize());
-		transitionTable = new TransitionTable(file, header.getTargetTableSize());
+		indexTable = new IndexTable(input, header.getIndexTableSize());
+		transitionTable = new TransitionTable(input, header.getTargetTableSize());
 	}
 
 	private int pivot(long i) {

--- a/src/main/java/fi/seco/hfst/WeightedTransducer.java
+++ b/src/main/java/fi/seco/hfst/WeightedTransducer.java
@@ -1,6 +1,6 @@
 package fi.seco.hfst;
 
-import java.io.DataInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
@@ -38,9 +38,9 @@ public class WeightedTransducer implements Transducer {
 			return Float.intBitsToFloat((int) ti_targets[i]);
 		}
 
-		public IndexTable(DataInputStream filestream, int indicesCount) throws java.io.IOException {
+		public IndexTable(InputStream input, int indicesCount) throws java.io.IOException {
 			ByteArray b = new ByteArray(indicesCount * 6);
-			filestream.readFully(b.getBytes());
+			input.read(b.getBytes());
 			// each index entry is a unsigned short followed by an unsigned int
 			ti_inputSymbols = new int[indicesCount];
 			ti_targets = new long[indicesCount];
@@ -65,10 +65,10 @@ public class WeightedTransducer implements Transducer {
 		private final long[] ti_targets;
 		private final float[] ti_weights;
 
-		public TransitionTable(DataInputStream filestream, int transitionCount) throws java.io.IOException {
+		public TransitionTable(InputStream input, int transitionCount) throws java.io.IOException {
 			ByteArray b = new ByteArray(transitionCount * 12);
 			// each transition entry is two unsigned shorts and an unsigned int
-			filestream.readFully(b.getBytes());
+			input.read(b.getBytes());
 			ti_inputSymbols = new int[transitionCount];
 			ti_outputSymbols = new int[transitionCount];
 			ti_targets = new long[transitionCount];
@@ -150,7 +150,7 @@ public class WeightedTransducer implements Transducer {
 		}
 	}
 
-	public WeightedTransducer(DataInputStream file, TransducerHeader h, TransducerAlphabet a) throws java.io.IOException {
+	public WeightedTransducer(InputStream file, TransducerHeader h, TransducerAlphabet a) throws java.io.IOException {
 		header = h;
 		alphabet = a;
 		operations = alphabet.operations;


### PR DESCRIPTION
this PR introduces the following changes
- read transducer input from generic InputStream
- upgrade com.carrotsearch.hppc library version
- upgrade source level to Java 1.8 (Java 7 has been EOL'd some time now)
- explicitly specify source encoding to make build deterministic
- change `pom.xml` indentation
