### PR TITLE
Update carrotsearch hppc 0.6.1 -> 0.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>com.carrotsearch</groupId>
 			<artifactId>hppc</artifactId>
-			<version>0.6.1</version>
+			<version>0.7.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/fi/seco/hfst/LetterTrie.java
+++ b/src/main/java/fi/seco/hfst/LetterTrie.java
@@ -1,12 +1,12 @@
 package fi.seco.hfst;
 
-import com.carrotsearch.hppc.CharIntOpenHashMap;
-import com.carrotsearch.hppc.CharObjectOpenHashMap;
+import com.carrotsearch.hppc.CharIntHashMap;
+import com.carrotsearch.hppc.CharObjectHashMap;
 
 public class LetterTrie {
 	public class LetterTrieNode {
-		private final CharIntOpenHashMap symbols;
-		private final CharObjectOpenHashMap<LetterTrieNode> children;
+		private final CharIntHashMap symbols;
+		private final CharObjectHashMap<LetterTrieNode> children;
 
 		public void addString(String str, int symbolNumber) {
 			if (str.length() > 1) {
@@ -41,8 +41,8 @@ public class LetterTrie {
 		}
 
 		public LetterTrieNode() {
-			symbols = new CharIntOpenHashMap();
-			children = new CharObjectOpenHashMap<LetterTrieNode>();
+			symbols = new CharIntHashMap();
+			children = new CharObjectHashMap<LetterTrieNode>();
 		}
 	}
 

--- a/src/main/java/fi/seco/hfst/TransducerAlphabet.java
+++ b/src/main/java/fi/seco/hfst/TransducerAlphabet.java
@@ -5,9 +5,9 @@ import java.util.ArrayList;
 
 import com.carrotsearch.hppc.ByteArrayList;
 import com.carrotsearch.hppc.IntObjectMap;
-import com.carrotsearch.hppc.IntObjectOpenHashMap;
+import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.ObjectIntMap;
-import com.carrotsearch.hppc.ObjectIntOpenHashMap;
+import com.carrotsearch.hppc.ObjectIntHashMap;
 
 /**
  * On instantiation reads the transducer's alphabet and provides an interface to
@@ -20,9 +20,9 @@ public class TransducerAlphabet {
 
 	public TransducerAlphabet(DataInputStream charstream, int number_of_symbols) throws java.io.IOException {
 		keyTable = new ArrayList<String>();
-		operations = new IntObjectOpenHashMap<FlagDiacriticOperation>();
-		ObjectIntMap<String> feature_bucket = new ObjectIntOpenHashMap<String>();
-		ObjectIntMap<String> value_bucket = new ObjectIntOpenHashMap<String>();
+		operations = new IntObjectHashMap<FlagDiacriticOperation>();
+		ObjectIntMap<String> feature_bucket = new ObjectIntHashMap<String>();
+		ObjectIntMap<String> value_bucket = new ObjectIntHashMap<String>();
 		features = 0;
 		int values = 1;
 		value_bucket.put("", 0); // neutral value


### PR DESCRIPTION
The reason behind this PR is that in one of our projects we have both [Elasticsearch](https://www.elastic.co/) and hfst as a dependency. Now, the latest version of Elasticsearch has a compile-dependency for `com.carrotsearch:hppc:0.7.1` (see [build.gradle](https://github.com/elastic/elasticsearch/blob/f71f0d601097f6de098baf2a93ed5e64678e1f68/core/build.gradle#L53)). Unfortunately hppc 0.6.1 and 0.7.1 are not compatible. Thus, we need a hfst implementation compiled against hppc 0.7.1
